### PR TITLE
fix: avoid mutating original data

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function mergeJSXProps (objs) {
           }
         }
       } else {
-        a[key] = b[key]
+        a[key] = copy(b[key])
       }
     }
     return a
@@ -47,4 +47,17 @@ function mergeFn (a, b) {
     a && a.apply(this, arguments)
     b && b.apply(this, arguments)
   }
+}
+
+function copy (val) {
+  if (typeof val === 'string'
+    || typeof val === 'number'
+    || val === null
+    || val === undefined) {
+    return val
+  }
+  if (Array.isArray(val)) {
+    return val.slice()
+  }
+  return Object.assign({}, val)
 }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ function mergeFn (a, b) {
 }
 
 function copy (val) {
-  if (typeof val === 'string'
+  if (val instanceof Function
+    || typeof val === 'string'
     || typeof val === 'number'
     || val === null
     || val === undefined) {


### PR DESCRIPTION
Fix related issue [vuejs/babel-plugin-transform-vue-jsx#171](https://github.com/vuejs/babel-plugin-transform-vue-jsx/issues/171)

Currently, the props are directly assigned to the result in the reduce function. The problem is when using spread operator in jsx, the parameter is the original object. As a result, when assigning something to `aa[nestedKey]`, it will mutate that object.

These changes fix the issue by copying the props instead of direct assignment. This PR also passed the test cases in [vuejs/babel-plugin-transform-vue-jsx](https://github.com/vuejs/babel-plugin-transform-vue-jsx).