### PR TITLE
"Uncaught SyntaxError: Invalid regular expression flags" on minified script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var nestRE = /^(attrs|props|on|nativeOn|class|style|hook)$/
+var nestRE = /^(attrs|props|on|nativeOn|class|style|hook)$/;
 
 module.exports = function mergeJSXProps (objs) {
   return objs.reduce(function (a, b) {


### PR DESCRIPTION
When minifying the script, the specified error occurs due to the fact that there is no semicolon in the first line